### PR TITLE
Fix `SOURCE_URL`

### DIFF
--- a/SOURCE_URL
+++ b/SOURCE_URL
@@ -1,1 +1,1 @@
-https://github.com/Xposed-Modules-Repo/com.luckyzyx.notifyintercept
+https://github.com/luckyzyx/NotifyIntercept


### PR DESCRIPTION
`SOURCE_URL` needs to point to the actual source code of the project, not the url to the xposed repository